### PR TITLE
Fix upstream issue #2

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
                             {{ end }}
                         {{ end }}
                     {{ end }}
-                    {{ range where .Site.Pages "Section" ""}}
+                    {{ range where .Site.RegularPages "Section" ""}}
                         {{ if ne .Title "Home"}}
                             <a href="{{ .Permalink }}"><li>{{ .Title }}</li></a>
                         {{ end }}


### PR DESCRIPTION
The header was including a number of meta-pages (tags, categories...).
Fixed by getting the list of pages from a "regular" page collection that doesn't include these meta-pages.

I believe this fixes the duplication problems that @Naata was experiencing without a hardcoded blacklist of pages, and it should also fix the demo on the themes website. Please confirm, as I literally began using Hugo and this theme less than a hour ago...