### PR TITLE
Hide blog link in header if there is no blog

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,9 @@
             <a href="{{ .Site.BaseURL }}"><div class="name"><h1>{{ .Site.Title }}</h1></div></a>
             <nav>
                 <ul>
-                    <a href="{{ .Site.BaseURL }}blog/"><li>Blog</li></a>
+                    {{ if ne (len (where .Site.RegularPages "Section" "blog")) 0 }}
+                        <a href="{{ .Site.BaseURL }}blog/"><li>Blog</li></a>
+                    {{ end }}
                     {{ range .Site.Sections }}
                         {{ range first 1 (where .Pages "Section" "ne" "")}}
                             {{ if ne .Section "blog"}}


### PR DESCRIPTION
Currently, the "Blog" link in the header is always shown, even if there aren't any blog posts. Apart from this, this theme works perfectly for a blog-less website (i.e. only pages). This minor change makes the blog link only appear if there are blog posts.