### PR TITLE
Fix the case where latestpostcount is missing from configuration.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,24 +8,26 @@
                 </div>
             {{ end }}
 
-            <div class="posts">
-            {{ $nbPosts := len (where .Data.Pages "Section" "blog") }}
-            {{ if gt $nbPosts 0 }}
-                <div class="page-heading">Latest posts</div>
-                <ul>
-                {{ range (first .Site.Params.latestpostcount (where .Pages "Section" "blog")).GroupByDate "Jan, 2006" "desc" }}
-                    <li class="groupby">{{ .Key }}</li>
-                    {{ range .Pages.ByPublishDate }}
-                        {{ partial "li.html" . }}
+            {{ if isset .Site.Params "latestpostcount" }}
+                <div class="posts">
+                {{ $nbPosts := len (where .Data.Pages "Section" "blog") }}
+                {{ if gt $nbPosts 0 }}
+                    <div class="page-heading">Latest posts</div>
+                    <ul>
+                    {{ range (first .Site.Params.latestpostcount (where .Pages "Section" "blog")).GroupByDate "Jan, 2006" "desc" }}
+                        <li class="groupby">{{ .Key }}</li>
+                        {{ range .Pages.ByPublishDate }}
+                            {{ partial "li.html" . }}
+                        {{ end }}
+                    {{ end }}
+                    </ul>
+
+                    {{ if gt $nbPosts .Site.Params.latestpostcount }}
+                        <a href="./blog/" class="see-more">See more ...</a>
                     {{ end }}
                 {{ end }}
-                </ul>
-
-                {{ if gt $nbPosts .Site.Params.latestpostcount }}
-                    <a href="./blog/" class="see-more">See more ...</a>
-                {{ end }}
+                </div>
             {{ end }}
-            </div>
 
             <div class="best-posts">
             {{ $nbPosts := len (where .Data.Pages "Params.best" true) }}


### PR DESCRIPTION
When the configuration parameter `latestpostcount` is missing, the template fails to parse and still display "Lates posts" on the index.
Imo, this case should be handled by the theme.