### PR TITLE
Added analytics support

### DIFF
--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -9,6 +9,10 @@
   <script src="{{ .Site.BaseURL }}js/progressively.min.js" defer></script>
 {{ end }}
 
+{{ if isset .Site.Params "googleanalytics" }}
+    {{ template "_internal/google_analytics.html" . }}
+{{ end }}
+
 <script>
   window.onload = function() {
     {{ if .Site.Params.highlightjs }}


### PR DESCRIPTION
Addressing #23. From my testing, the script is only added when the analytics parameter is set. An addition to the wiki might be useful along these lines:

"To add google analytics, add a parameter of the form `googleanalytics = "UA-123-45"` to your config.toml"

The only usage difference from the guide found [here](https://gohugo.io/extras/analytics/) is that this template uses .toml instead of .yaml, so the parameter name is fully lowercase.