### PR TITLE
Adds author information on blog posts

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -7,15 +7,13 @@
                 <div class="title-container">
                     {{ partial "page-heading" . }}
                 </div>
-                {{ if not .Params.noauthor }}
-                    {{ if .Params.author }}
-                        <div class="author-container">
-                            <div class="author" title="{{ .Params.Author }}">{{ .Params.author }}</div>
-                        </div>
-                    {{end}}
-                {{end}}
                 <div class="meta">
                     <div class="date" title="{{ .Date.Format .Site.Params.dateformfull }}">{{ .Date.Format .Site.Params.dateform }}</div>
+                    {{ if not .Params.noauthor }}
+                        {{ if .Params.author }}
+                        <div class="author" title="{{ .Params.Author }}"><div class="middot"></div>{{ .Params.author }}</div>
+                        {{end}}
+                    {{end}}
                     <div class="reading-time"><div class="middot"></div>{{ if eq 1 .ReadingTime }}{{ .ReadingTime }} minute read{{ else }}{{ .ReadingTime }} minutes read{{ end }}</div>
                 </div>
             </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -7,6 +7,13 @@
                 <div class="title-container">
                     {{ partial "page-heading" . }}
                 </div>
+                {{ if not .Params.noauthor }}
+                    {{ if .Params.author }}
+                        <div class="author-container">
+                            <div class="author" title="{{ .Params.Author }}">{{ .Params.author }}</div>
+                        </div>
+                    {{end}}
+                {{end}}
                 <div class="meta">
                     <div class="date" title="{{ .Date.Format .Site.Params.dateformfull }}">{{ .Date.Format .Site.Params.dateform }}</div>
                     <div class="reading-time"><div class="middot"></div>{{ if eq 1 .ReadingTime }}{{ .ReadingTime }} minute read{{ else }}{{ .ReadingTime }} minutes read{{ end }}</div>

--- a/static/css/main.v0.9.1.css
+++ b/static/css/main.v0.9.1.css
@@ -492,6 +492,7 @@ section.main .content .front-matter .meta {
   margin-bottom: 32px;
 }
 section.main .content .front-matter .date,
+section.main .content .front-matter .author,
 section.main .content .front-matter .word-count,
 section.main .content .front-matter .reading-time .middot {
   display: none;
@@ -507,6 +508,7 @@ section.main .content .front-matter .middot:before {
 }
 @media (min-width: 600px) {
   section.main .content .front-matter .date,
+  section.main .content .front-matter .author,
   section.main .content .front-matter .word-count,
   section.main .content .front-matter .reading-time .middot {
     display: initial;


### PR DESCRIPTION
Simply just adds names based on front matter in the post itself using the `author` parameter.

Can be fully disabled in the `config.toml` with the `noauthor` parameter