### PR TITLE
A working implementation of social links

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -2,5 +2,7 @@
 meta_img = "/images/image.jpg"
 tags = ["tags"]
 description = "Desc"
+hacker_news_id = ""
+lobsters_id = ""
 title = "Title"
 +++

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -25,9 +25,13 @@
                     </div>
                     <div class="tags">
                         <ul>
-                          {{ range .Params.socialLinks }}
+                          {{ if isset .Params "hacker_news_id" }}
                             <div class="middot"></div>
-                            <li><a href="{{ index . 1 }}">{{ index . 0 }}</a> </li>
+                            <li><a href="https://news.ycombinator.com/item?id={{ .Params.hacker_news_id }}">Hacker News</a> </li>
+                          {{ end }}
+                          {{ if isset .Params "lobsters_id" }}
+                            <div class="middot"></div>
+                            <li><a href="https://lobste.rs/s/{{ .Params.lobsters_id }}">Lobsters</a> </li>
                           {{ end }}
                         </ul>
                     </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -23,6 +23,14 @@
                           {{ end }}
                         </ul>
                     </div>
+                    <div class="tags">
+                        <ul>
+                          {{ range .Params.socialLinks }}
+                            <div class="middot"></div>
+                            <li><a href="{{ index . 1 }}">{{ index . 0 }}</a> </li>
+                          {{ end }}
+                        </ul>
+                    </div>
                 </div>
             </div>
             <div class="markdown">


### PR DESCRIPTION
This is a pull request that follows up on the feature I suggested in #37. I'm not sure if there's a particularly good way to implement this that I'm missing, but here's what I did:

A user would include a `socialLinks` param in their content header (so before this changes is finalized and merged, it should be added to the default archetype). `socialLinks` is an array of arrays, each of which has the social site name as its first param and the absolute link to the content as its second. I did this because it allows for easy iteration in the template, but it produces a few concerns:

1. Typing the name of the social site repeatedly seems cumbersome and error-prone. Maybe it's just better to have a param for each supported site?
2. Absolute links aren't very nice, in my opinion. But it gets worse. If the user provides a proper link, all is well (ex. "https://www.google.com"). But if they provide something like "www.google.com" it is converted to a relative url. There may be a way be a way of dealing with this that I'm not aware of, though. Switching away from the array would make this easier to deal with too. For example, since we know that hacker news refers to content by IDs, the `hackerNews` param could take a content-id, while the `lobste.rs` one could take a title.

Anyways, I'd appreciate your input (and anyone else who follows the theme)! All told, this is how it looks right now:

<img width="703" alt="screen shot 2017-06-09 at 6 13 22 pm" src="https://user-images.githubusercontent.com/4515110/26997660-1bd96718-4d41-11e7-96d8-884d0938bdac.png">

And the relevant corresponding param:

```
socialLinks = [["Hacker News","someAbsUrl"],["Lobsters","someAbsUrl"]]
```
