### PR TITLE
Add feature for 3rd party license URLs

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -19,6 +19,7 @@ dateform = "Jan 2, 2006"
 dateformfull = "Mon Jan 2 2006 15:04:05 MST"
 description = "Example blog"
 copyright = "Copyright © 2015 Nishanth Shanmugham"
+# copyrightUrl = "https://creativecommons.org/licenses/by-sa/4.0/"
 logofile = "img/logo.png"
 faviconfile = "img/logo.png"
 highlightjs = true

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,11 @@
         <div class="copyright">
 
         {{ if .Site.Params.copyright }}
-            <a href="{{ .Site.BaseURL }}license">{{ .Site.Params.copyright}}</a>
+            {{ if .Site.Params.copyrightUrl }}
+                <a href="{{ .Site.Params.copyrightUrl }}">{{ .Site.Params.copyright }}</a>
+            {{ else }}
+                <a href="{{ .Site.BaseURL }}license">{{ .Site.Params.copyright }}</a>
+            {{ end }}
         {{ end }}
 
         </div>


### PR DESCRIPTION
This PR adds the feature to specify an URL where the license lives instead of using `/license`. To enable it specify a `copyrightUrl` in your config file.