### PR TITLE
Add feature for linking to a GitHub repository where the blog lives

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -30,6 +30,7 @@ linkedin = "john-example-aa80ue8è"
 twitter = "example"
 social_banner = "img/banner.png"
 posts_navigation = true
+# githubRepo = "githubUsername/repositoryName"
 
 [params.colors]
 identifier = "#527fc1f"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,12 @@
 <section class="footer">
     <div class="container">
+
+        {{ if .Site.Params.githubRepo }}
+        <div class="copyright">
+            <a href="https://github.com/{{ .Site.Params.githubRepo }}/tree/master/content/{{ .File.Path }}" target="_blank">View this post on GitHub</a>
+        </div>
+        {{ end }}
+
         <div class="copyright">
 
         {{ if .Site.Params.copyright }}


### PR DESCRIPTION
This PR adds the feature to specify a GitHub repository where the blog lives and adds links on every post that point to the according post on GitHub. To enable it add `githubRepo = "user/repo"` to your config.

(Uses `class="copyright"` in CSS, not happy with that but was straightforward.)