### PR TITLE
Enable left alignment as an option

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,11 +1,10 @@
 +++
-title: "{{ replace .TranslationBaseName "-" " " | title }}"
-date: {{ .Date }}
-draft: true
+title = "{{ replace .TranslationBaseName "-" " " | title }}"
+date = {{ .Date }}
+draft = true
 meta_img = "/images/image.jpg"
 tags = ["tags"]
 description = "Desc"
 hacker_news_id = ""
 lobsters_id = ""
-title = "Title"
 +++

--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -507,7 +507,11 @@ section.main .content .markdown a code:hover {
   text-decoration: underline;
 }
 section.main .content .markdown p {
+  {{if .Site.Params.align_left}}
+  text-align: left;
+  {{else}}
   text-align: justify;
+  {{end}}
   margin-top: 0;
   margin-bottom: 1em;
 }


### PR DESCRIPTION
A minor change in response to #50. This PR implements the option to use left alignment rather than justify for the body of content. It can be enabled by setting `align_left = true` in the site config file.