### PR TITLE
Correct license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ Pull requests, bug fixes, and new features are welcome!
 
 ## License
 
-Licensed under the MIT License. See the [LICENSE](https://github.com/fuegowolf/cocoa-eh-hugo-theme/blob/master/LICENSE.md) file for more details.
+Licensed under the MIT License. See the [LICENSE](https://github.com/fuegowolf/cocoa-eh-hugo-theme/blob/master/LICENSE) file for more details.


### PR DESCRIPTION
`LICENSE.md` -> `LICENSE`

Tiny change, but I noticed a broken link so I figured it was a small enough effort to make the change and merge that it might as well be fixed :wolf: