### PR TITLE
Fix archetypes bug with Go templates

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,5 @@
 +++
-title = "{{ replace .TranslationBaseName "-" " " | title }}"
+title = '{{ replace .TranslationBaseName "-" " " | title }}'
 date = {{ .Date }}
 draft = true
 meta_img = "/images/image.jpg"


### PR DESCRIPTION
I had problem with importing site with your theme to forestry.io and asked them why. Provided response:


Hi there,
I jumped into your account to take a look at the logs. This is one of the few Hugo errors that we have a hard time catching and providing to the user.
Your site and/or theme has archetypes with with GoTemplate syntax in them. Unfortunately, GoTemplate-based archetypes actually break the TOML & YAML rules, so they cause imports to fail.
You can fix this by making sure all of your archetypes put any GoTemplate syntax inside of strings. Also ensure the string isn't terminated by the GoTemplate syntax.
E.g,

`title: "{{ replace .TranslationBaseName "-" " " | title }}"`

becomes

`title: '{{ replace .TranslationBaseName "-" " " | title }}'`

So that the GoTemplate syntax is wrapped in single quotes, and any strings inside the GoTemplate syntax are double quotes.
Let me know if you have any questions!
Cheers,
Chris