### PR TITLE
Add latex support

### DIFF
--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -52,3 +52,10 @@
     {{ end }}
   };
 </script>
+
+{{ if .Site.Params.uselatex }}
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] } });
+</script>
+<script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML"></script>
+{{ end }}


### PR DESCRIPTION
Addresses #64, @caspern

To use, set param `uselatex` in config file. If this option isn't set to true, the files needed for rendering aren't sourced, adding no bulk to the theme for those that don't want to render latex.

Current syntax is to use normal latex delimiters without surrounding ``, I think. At least $3$ and $$3$$ are rendered correctly.

To do before merging:
- [x] Check if less stuff needs to be pulled in from CDN
- [x] Look into potential problems mentioned [here](https://gohugo.io/content-management/formats/)
- [x] Look into using normal code delimiters for latex blocks and inline latex, because I think other themes do this without problems

:frog: