### PR TITLE
Sort posts reverse chronologically

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
                     <ul>
                     {{ range (first .Site.Params.latestpostcount (where .Pages "Section" "blog")).GroupByDate "Jan, 2006" "desc" }}
                         <li class="groupby">{{ .Key }}</li>
-                        {{ range .Pages.ByPublishDate }}
+                        {{ range sort .Pages "Date" "desc" }}
                             {{ partial "li.html" . }}
                         {{ end }}
                     {{ end }}
@@ -34,7 +34,7 @@
             {{ if gt $nbPosts 0 }}
                 <div class="page-heading">Best posts</div>
                 <ul>
-                {{ range .Data.Pages.ByPublishDate }}
+                {{ range sort .Data.Pages "Date" "desc" }}
                     {{ if eq .Params.best true }}
                         {{ partial "li.html" . }}
                     {{ end }}
@@ -46,4 +46,3 @@
     </div>
 </div>
 {{ partial "footer.html" . }}
-

--- a/layouts/section/blog.html
+++ b/layouts/section/blog.html
@@ -7,7 +7,7 @@
                 <ul>
                     {{ range .Data.Pages.GroupByDate "Jan, 2006" "desc"}}
                         <li class="groupby">{{ .Key }}</li>
-                        {{ range .Pages.ByPublishDate }}
+                        {{ range sort .Pages "Date" "desc" }}
                             {{ partial "li.html" . }}
                         {{ end }}
                     {{ end }}


### PR DESCRIPTION
The months are displayed reverse chronologically, but the posts for that month
are displayed chronologically.  It seems more intuitive to have posts under each
month also to be sorted reverse chronologically.