### PR TITLE
css: remove unused fonts from CSS

### DIFF
--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -691,27 +691,3 @@ div.main .content .share {
 div.main .content .share a {
   margin: 0 6px;
 }
-
-/* Fonts */
-
-.wf-raleway-n4-active body, 
-.wf-raleway-n4-active div.header nav ul a,
-.wf-raleway-n7-active div.main .content .page-heading,
-.wf-raleway-n2-active div.main .container.f04 .content .num,
-.wf-raleway-n7-active div.main .content .markdown h1,
-.wf-raleway-n7-active div.main .content .markdown h2,
-.wf-raleway-n7-active div.main .content .markdown h3,
-.wf-raleway-n7-active div.main .content .markdown h4,
-.wf-raleway-n7-active div.main .content .markdown h5,
-.wf-raleway-n7-active div.main .content .markdown h6 {
-  font-family: 'Raleway';
-}
-
-.wf-merriweather-n3-active div.main .content .markdown {
-  font-family: 'Merriweather';
-}
-
-.wf-ubuntu-mono-n4-active div.main .content .markdown code,
-.wf-ubuntu-mono-n4-active div.main .content .markdown pre {
-  font-family: 'Ubuntu Mono';
-}


### PR DESCRIPTION
For a while now I have had the fonts on my website "jump" (rescale?) to a smaller size upon loading a page. I finally had time to track it down and found the cause. These lines here seem to be unused, and when removed they stop the fonts from jumping.

You can try to reproduce on [my website](https://hjdskes.github.io).