### PR TITLE
css: add kbd styling

### DIFF
--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -691,3 +691,22 @@ div.main .content .share {
 div.main .content .share a {
   margin: 0 6px;
 }
+kbd {
+  padding: 0.1em 0.6em;
+  border: 1px solid #ccc;
+  font-size: 11px;
+  font-family: Arial,Helvetica,sans-serif;
+  background-color: #f7f7f7;
+  color: #333;
+  -moz-box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+  -webkit-box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+  box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+  display: inline-block;
+  margin: 0 0.1em;
+  text-shadow: 0 1px 0 #fff;
+  line-height: 1.4;
+  white-space: nowrap;
+}


### PR DESCRIPTION
I'm cleaning up my CSS overrides and found this one. I think it is a good addition to Cocoa-eh's default CSS :) For an example, see [this page](https://hjdskes.github.io/blog/gsoc-part-9/) in e.g. bullet 2 directly under the first video.

I think originally I copied this from a StackOverflow answer, but I cannot seem to find the original. [This](https://meta.superuser.com/questions/4788/css-for-the-new-kbd-style) SO post seems to be the same style, though.

Edit: fix link (mtn)