### PR TITLE
Make Logo Optional by providing an empty string

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,7 +11,9 @@
 <div class="header header-home column">
 {{ end }}
     <div class="container">
+        {{ if ne .Site.Params.logofile "" }}
         <a href="{{ .Site.BaseURL }}"><img class="logo" src="{{ .Site.Params.logofile | absURL }}" alt="logo" /></a>
+        {{ end }}
         <div class="content">
             <a href="{{ .Site.BaseURL }}"><div class="name"><h1>{{ .Site.Title }}</h1></div></a>
             <nav>


### PR DESCRIPTION
Since not every user has a nice logo at hand I find it useful to have the option to not include a logo. By default cocoa-eh would still show a 'logo' hyperlink. I would at least try to make this theme work without any basefiles given (even thoug the basic cocoa theme is available)

Signed-off-by: Robin Wenzel <info@robin-wenzel.de>