### PR TITLE
View this post on Github handles Windows paths

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,9 +5,9 @@
             <div class="copyright">
             {{ $length := len ( split .Site.Params.githubRepo "/" ) }}
             {{ if eq $length 2 }}
-                <a href="https://github.com/{{ .Site.Params.githubRepo }}/tree/master/content/{{ .File.Path }}" target="_blank">View this post on GitHub</a>
+                <a href="https://github.com/{{ .Site.Params.githubRepo }}/tree/master/content/{{ replace .File.Path "\\" "/" }}" target="_blank">View this post on GitHub</a>
             {{ else }}
-                <a href="https://github.com/{{ .Site.Params.githubRepo }}/content/{{ .File.Path }}" target="_blank">View this post on GitHub</a>
+                <a href="https://github.com/{{ .Site.Params.githubRepo }}/content/{{ replace .File.Path "\\" "/" }}" target="_blank">View this post on GitHub</a>
             {{ end }}
             </div>
         {{ end }}


### PR DESCRIPTION
Hey,

I noticed a problem with the "View this post on Github" link. The link to the file is created with the variable ``.File.Path``. It seems like this variable returns os-specific paths. On a windows machine it returns ``blog\\random_post.md`` where the double backlashes are replaced by ``%5c`` in the final link.

My fix replaces double backlashes with one foreslash, so that the link works again.

Best

Tobias