### PR TITLE
Only load isso script and css on pages that support comments

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,5 +1,13 @@
 {{ partial "header.html" . }}
 
+{{ if .Site.Params.issoHost }}
+  <style type="text/css" media="screen">
+    .isso section {
+      margin: 0px;
+    }
+  </style>
+{{ end }}
+
 <div class="main post non-narrow zero-top-spacing column">
     <div class="container">
         <div class="content">
@@ -73,6 +81,12 @@
             </div>
             {{ if .Site.Params.issoHost }}
             <div class="isso" id="isso-thread"></div>
+            <script
+                data-isso="//{{ .Site.Params.issoHost }}/"
+                data-isso-css="true"
+                data-isso-lang="{{ .Site.LanguageCode }}"
+                src="//{{ .Site.Params.issoHost }}/js/embed.min.js"
+            ></script>
             {{ end }}
         </div>
     </div>

--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -20,16 +20,6 @@
   <script src="{{ .Site.BaseURL }}js/progressively.min.js" defer></script>
 {{ end }}
 
-
-{{ if .Site.Params.issoHost }}
-<script
-  data-isso="//{{ .Site.Params.issoHost }}/"
-  data-isso-css="true"
-  data-isso-lang="{{ .Site.LanguageCode }}"
-  src="//{{ .Site.Params.issoHost }}/js/embed.min.js"
-></script>
-{{ end }}
-
 {{ if .Site.Params.share }}
   <script src="{{ .Site.BaseURL }}js/social-share-kit.min.js" defer></script>
 {{ end }}

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -44,14 +44,6 @@
   <link rel="stylesheet" href="{{ . | absURL }}">
 {{ end }}
 
-{{ if .Site.Params.issoHost }}
-  <style type="text/css" media="screen">
-    .isso section {
-      margin: 0px;
-    }
-  </style>
-{{ end }}
-
 <!-- Icon -->
 <link rel="shortcut icon"
 {{ if .Site.Params.faviconfile }}


### PR DESCRIPTION
I move isso script and css from footer and head to blog/single.html.
But I noticed that the script tag and css tag may have wrong way and I can't find a smart way to solve this problem.