### PR TITLE
Enable partial sharing

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -25,6 +25,9 @@ faviconfile = "img/logo.png"
 highlightjs = true
 progressively = true
 share = true
+# Share to googleplus, twitter, fb, linkedin by default
+# disable by setting share_on_<social network> = false
+# example: share_on_googleplus = false
 latestpostcount = 5
 github = "example"
 email = "you@example.com"

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -52,10 +52,18 @@
             </div>
             {{ if .Site.Params.share }}
             <div class="share">
-                <a href="" class="ssk ssk-facebook"></a>
-                <a href="" class="ssk ssk-twitter"></a>
-                <a href="" class="ssk ssk-google-plus"></a>
-                <a href="" class="ssk ssk-linkedin"></a>
+                  {{ if .Site.Params.share_on_fb | default true }}
+                  <a href="" class="ssk ssk-facebook"></a>
+                  {{ end }}
+                  {{ if .Site.Params.share_on_twitter | default true }}
+                  <a href="" class="ssk ssk-twitter"></a>
+                  {{ end }}
+                  {{ if .Site.Params.share_on_googleplus | default true }}
+                  <a href="" class="ssk ssk-google-plus"></a>
+                  {{ end }}
+                  {{ if .Site.Params.share_on_linkedin | default true }}
+                  <a href="" class="ssk ssk-linkedin"></a>
+                  {{ end }}
             </div>
             {{ end }}
             {{ if .Site.Params.posts_navigation }}


### PR DESCRIPTION
It is currently not possible to disable the sharing on a specific
site, say google plus or facebook.

This allows a configuration item switch to tweak this behavior.