### PR TITLE
Allow css transformations of title in config

### DIFF
--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -165,11 +165,11 @@ div.header .name {
   font-size: 28px;
   font-family: 'Nexa Bold', 'Helvetica Neue', 'Arial', sans-serif;
   letter-spacing: -0.005rem;
-  {{ if isset .Site.Params "title_style" }}
-      {{ if in "capitalize uppercase lowercase none full-width" .Site.Params.title_style }}
-  text-transform: {{ .Site.Params.title_style }};
+  {{ if isset .Site.Params "titlestyle" }}
+      {{ if in "capitalize uppercase lowercase none full-width" .Site.Params.titlestyle }}
+  text-transform: {{ .Site.Params.titlestyle }};
       {{ else }}
-      {{ errorf "This title_style is not a valid text-transform css parameter: %s" .Site.Params.title_style }}
+      {{ errorf "This titlestyle is not a valid text-transform css parameter: %s" .Site.Params.titlestyle }}
       {{ end }}
   {{ else }}
   text-transform: uppercase;

--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -165,7 +165,15 @@ div.header .name {
   font-size: 28px;
   font-family: 'Nexa Bold', 'Helvetica Neue', 'Arial', sans-serif;
   letter-spacing: -0.005rem;
+  {{ if isset .Site.Params "title_style" }}
+      {{ if in "capitalize uppercase lowercase none full-width" .Site.Params.title_style }}
+  text-transform: {{ .Site.Params.title_style }};
+      {{ else }}
+      {{ errorf "This title_style is not a valid text-transform css parameter: %s" .Site.Params.title_style }}
+      {{ end }}
+  {{ else }}
   text-transform: uppercase;
+  {{ end }}
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;


### PR DESCRIPTION
By default the style uppercases the title.
We can add extra css but that might be overkill for just one
change: Not capitalizing the title default.

This allows the title to be fully lowercase, by simply overriding
the theme configuration.