### PR TITLE
Fixed Disqus template check failing

### DIFF
--- a/layouts/partials/blog_single.html
+++ b/layouts/partials/blog_single.html
@@ -82,7 +82,7 @@
                 {{ end }}
             </div>
             {{ end }}
-            {{ if .Site.Params.disqusShortname }}
+            {{ if .Site.DisqusShortname }}
             <br>
             <div class="disqus">
                 {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
Disqus wasn't appearing on my post, because the template checks for a param, while disqusShortname is a top-level config value.