### PR TITLE
Using relative links for blog entries

### DIFF
--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -1,8 +1,8 @@
 <li class="post-item">
     <span class="meta">{{ .Date.Format .Site.Params.dateform }}</span>
     {{ if .Params.draft }}
-    <a href="{{ .Permalink }}"><span>Draft::{{ .Title }}</span></a>
+    <a href="{{ .RelPermalink }}"><span>Draft::{{ .Title }}</span></a>
     {{ else }}
-    <a href="{{ .Permalink }}"><span>{{ .Title }}</span></a>
+    <a href="{{ .RelPermalink }}"><span>{{ .Title }}</span></a>
     {{ end }}
 </li>


### PR DESCRIPTION
Using relative links is very useful when sites are published in [Netlify deploy previews](https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/). Those are unique (per-PR) URLs that you can use to preview what the site would look like it it were merged to master. With relative links, you can click through to the post and stay on the preview site.