### PR TITLE
add terms.html to layouts/_default folder

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,16 @@
+{{ partial "header.html" . }}
+
+<h1>{{ .Title }}</h1>
+
+<ul class="terms">
+  {{ range $key, $value := .Data.Terms }}
+  <li>
+    <a href="{{ (print "/" $.Data.Plural "/" $key | urlize) | relURL }}">
+      {{ $key }}
+    </a>
+    ({{ len $value }})
+  </li>
+  {{ end }}
+</ul>
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Hello,

I've been trying to use this theme with Hugo version 0.52 via the R package "blogdown". I've successfully used the theme before with no issues (https://github.com/apreshill/ada-blog), but since updating Hugo to the most recent version I got a series of warnings:

```
> blogdown:::serve_site()
Building sites … WARN 2018/11/30 07:04:15 Found no layout for "taxonomyTerm", language "en", output format "HTML": create a template below /layouts with one of these filenames: categories/category.terms.en.html.html, categories/terms.en.html.html, categories/list.en.html.html, categories/category.terms.html.html, categories/terms.html.html, categories/list.html.html, categories/category.terms.en.html, categories/terms.en.html, categories/list.en.html, categories/category.terms.html, categories/terms.html, categories/list.html, taxonomy/category.terms.en.html.html, taxonomy/terms.en.html.html, taxonomy/list.en.html.html, taxonomy/category.terms.html.html, taxonomy/terms.html.html, taxonomy/list.html.html, taxonomy/category.terms.en.html, taxonomy/terms.en.html, taxonomy/list.en.html, taxonomy/category.terms.html, taxonomy/terms.html, taxonomy/list.html, category/category.terms.en.html.html, category/terms.en.html.html, category/list.en.html.html, category/category.terms.html.html, category/terms.html.html, category/list.html.html, category/category.terms.en.html, category/terms.en.html, category/list.en.html, category/category.terms.html, category/terms.html, category/list.html, _default/category.terms.en.html.html, _default/terms.en.html.html, _default/list.en.html.html, _default/category.terms.html.html, _default/terms.html.html, _default/list.html.html, _default/category.terms.en.html, _default/terms.en.html, _default/list.en.html, _default/category.terms.html, _default/terms.html, _default/list.html
WARN 2018/11/30 07:04:15 Found no layout for "taxonomyTerm", language "en", output format "HTML": create a template below /layouts with one of these filenames: tags/tag.terms.en.html.html, tags/terms.en.html.html, tags/list.en.html.html, tags/tag.terms.html.html, tags/terms.html.html, tags/list.html.html, tags/tag.terms.en.html, tags/terms.en.html, tags/list.en.html, tags/tag.terms.html, tags/terms.html, tags/list.html, taxonomy/tag.terms.en.html.html, taxonomy/terms.en.html.html, taxonomy/list.en.html.html, taxonomy/tag.terms.html.html, taxonomy/terms.html.html, taxonomy/list.html.html, taxonomy/tag.terms.en.html, taxonomy/terms.en.html, taxonomy/list.en.html, taxonomy/tag.terms.html, taxonomy/terms.html, taxonomy/list.html, tag/tag.terms.en.html.html, tag/terms.en.html.html, tag/list.en.html.html, tag/tag.terms.html.html, tag/terms.html.html, tag/list.html.html, tag/tag.terms.en.html, tag/terms.en.html, tag/list.en.html, tag/tag.terms.html, tag/terms.html, tag/list.html, _default/tag.terms.en.html.html, _default/terms.en.html.html, _default/list.en.html.html, _default/tag.terms.html.html, _default/terms.html.html, _default/list.html.html, _default/tag.terms.en.html, _default/terms.en.html, _default/list.en.html, _default/tag.terms.html, _default/terms.html, _default/list.html
```

After some searching, I found that adding a `terms.html` file to `layouts/_default/` fixed the problem. I copied the text of this file from [the xmin Hugo theme](https://github.com/yihui/hugo-xmin/tree/master/layouts/_default). 

This PR adds the same `terms.html` file to `layouts/_default/` and works with Hugo version 0.52.