### PR TITLE
Using relative URLs in the header

### DIFF
--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -41,13 +41,13 @@
 {{ end }}
 
 {{ range .Site.Params.extracssfiles }}
-  <link rel="stylesheet" href="{{ . | absURL }}">
+  <link rel="stylesheet" href="{{ . | relURL }}">
 {{ end }}
 
 <!-- Icon -->
 <link rel="shortcut icon"
 {{ if .Site.Params.faviconfile }}
-    href="{{ .Site.Params.faviconfile | absURL }}"
+    href="{{ .Site.Params.faviconfile | relURL }}"
 {{ else }}
     href="{{ .Site.BaseURL }}img/favicon.ico"
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,19 +14,19 @@
         {{ if (not (isset .Site.Params "logofile")) }}
         <a href="https://github.com/mtn/cocoa-eh-hugo-theme/wiki/Configuration#logo">Logo HOWTO</a>
         {{ else if ne .Site.Params.logofile "" }}
-        <a href="{{ .Site.BaseURL }}"><img class="logo" src="{{ .Site.Params.logofile | absURL }}" alt="logo"></a>
+        <a href="{{ .Site.BaseURL }}"><img class="logo" src="{{ .Site.Params.logofile | relURL }}" alt="logo"></a>
         {{ end }}
         <div class="content">
             <a href="{{ .Site.BaseURL }}"><div class="name"><h1>{{ .Site.Title }}</h1></div></a>
             <nav>
                 <ul>
                     {{ if (and (ne (len (where .Site.RegularPages "Section" "blog")) 0) (not (in .Site.Params.exclude_headings "blog"))) }}
-                            <li><a href="{{ .Site.BaseURL }}blog/">Blog</a></li>
+                            <li><a href="/blog/">Blog</a></li>
                     {{ end }}
                     {{ range $.Site.Home.Sections }}
                         {{ range first 1 (where .Pages "Section" "ne" "")}}
                             {{ if (and (ne .Section "blog") (not (in .Site.Params.exclude_headings (lower .Section))))}}
-                            <li><a href="{{ .Section | urlize | absURL }}">{{ .Section }}</a></li>
+                            <li><a href="{{ .Section | urlize | relURL }}">{{ .Section }}</a></li>
                             {{ end }}
                         {{ end }}
                     {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
         <a href="{{ .Site.BaseURL }}"><img class="logo" src="{{ .Site.Params.logofile | relURL }}" alt="logo"></a>
         {{ end }}
         <div class="content">
-            <a href="{{ .Site.BaseURL }}"><div class="name"><h1>{{ .Site.Title }}</h1></div></a>
+            <a href="/"><div class="name"><h1>{{ .Site.Title }}</h1></div></a>
             <nav>
                 <ul>
                     {{ if (and (ne (len (where .Site.RegularPages "Section" "blog")) 0) (not (in .Site.Params.exclude_headings "blog"))) }}
@@ -32,7 +32,7 @@
                     {{ end }}
                     {{ range where .Site.RegularPages "Section" ""}}
                         {{ if (and (and (ne .Title "License") (ne .Title "Home")) (not (in .Site.Params.exclude_headings (lower .Title))))}}
-                            <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+                            <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
                         {{ end }}
                     {{ end }}
                 </ul>


### PR DESCRIPTION
When you preview the site at a "staging" URL (like Netlify pull request previews),
the header links go back to the production site. It's more convenient to make
the links relative in the header