### PR TITLE
Add utteranc.es comment support

### DIFF
--- a/layouts/partials/blog_single.html
+++ b/layouts/partials/blog_single.html
@@ -107,6 +107,20 @@
             <div id="commento"></div>
             <script src="//{{ .Site.Params.commentoHost }}/js/commento.js"></script>
             {{ end }}
+
+            {{ if .Site.Params.utterancHost}}
+            <br>
+            <div class="post bg-white">
+              <script src="https://utteranc.es/client.js"
+                    repo= "{{ .Site.Params.utterancHost }}"
+                    issue-term="pathname"
+                    theme="github-light"
+                    crossorigin="anonymous"
+                    async>
+              </script>
+            </div>
+            {{ end }}
+
         </div>
     </div>
 </div>


### PR DESCRIPTION
Adds support for ([utteranc.es](https://utteranc.es)) comments, which uses GitHub issues to keep comment data. Requires setup at the utteranc.es website, but uses GitHub accounts for commenters, and no tracking/advertising etc. Would need the wiki changed slightly to document this as well.

Using default `GitHub Light` theme to keep with the theme, I think the style matches quite well, here is a screenshot:

![Screenshot from 2019-06-22 17-34-52](https://user-images.githubusercontent.com/3956920/59966389-15d9f180-9514-11e9-9e8e-09c5227ae36f.png)


