### PR TITLE
wrap min_version in quotes for valid theme.toml file

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Cocoa Enhanced is a clean, fast and responsive theme with cool ty
 homepage = "https://github.com/fuegowolf/cocoa-eh-hugo-theme"
 tags = ["clean", "fast", "responsive", "typography"]
 features = ["flexible", "fast", "highlights", "progressive images", "disqus"]
-min_version = 0.20.2
+min_version = "0.20.2"
 
 [author]
     name = "Alexis Tacnet"


### PR DESCRIPTION
Attempting to run hugo with this theme currently throws an error: `unmarshal failed: Near line 8 (last key parsed 'min_version'): Invalid float value: "0.20.2"`.

Wrapping the min_version number in the theme.toml file fixes this