### PR TITLE
Don't put logofile on 404 page if it doesn't exist

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -9,7 +9,11 @@
 </style>
 </head>
 <body>
-    <img src={{ .Site.Params.logofile }} class="logo" alt="logo" />
+    {{ if (not (isset .Site.Params "logofile")) }}
+    <a href="https://github.com/mtn/cocoa-eh-hugo-theme/wiki/Configuration#logo">Logo HOWTO</a>
+    {{ else if ne .Site.Params.logofile "" }}
+    <img class="logo" src="{{ .Site.Params.logofile | relURL }}" alt="logo">
+    {{ end }}
     <div class="container f04">
         <div class="content">
             <div class="header column">


### PR DESCRIPTION
Currently, if the parameter logofile is set to "", the 404 page shows a broken image. This modification updates the 404 page to follow the logic of header.html and only show the logo if it isn't empty.