### PR TITLE
Hugo 0.58 - Use RegularPages if Available

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,13 +8,18 @@
                 </div>
             {{ end }}
 
+            {{ $pages := .Data.Pages }}
+            {{ if .IsHome }}
+            {{ $pages = .Site.RegularPages }}
+            {{ end }}
+
             {{ if isset .Site.Params "latestpostcount" }}
                 <div class="posts">
-                {{ $nbPosts := len (where .Data.Pages "Section" "blog") }}
+                {{ $nbPosts := len (where $pages "Section" "blog") }}
                 {{ if gt $nbPosts 0 }}
                     <div class="page-heading">Latest posts</div>
                     <ul>
-                    {{ range (first .Site.Params.latestpostcount (where .Pages "Section" "blog")).GroupByDate "Jan, 2006" "desc" }}
+                    {{ range (first .Site.Params.latestpostcount (where $pages "Section" "blog")).GroupByDate "Jan, 2006" "desc" }}
                         <li class="groupby">{{ .Key }}</li>
                         {{ range sort .Pages "Date" "desc" }}
                             {{ partial "li.html" . }}
@@ -30,11 +35,11 @@
             {{ end }}
 
             <div class="best-posts">
-            {{ $nbPosts := len (where .Data.Pages "Params.best" true) }}
+            {{ $nbPosts := len (where $pages "Params.best" true) }}
             {{ if gt $nbPosts 0 }}
                 <div class="page-heading">Best posts</div>
                 <ul>
-                {{ range sort .Data.Pages "Date" "desc" }}
+                {{ range sort $pages "Date" "desc" }}
                     {{ if eq .Params.best true }}
                         {{ partial "li.html" . }}
                     {{ end }}

--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -289,7 +289,11 @@ div.main .content .title-container {
   justify-content: space-between;
 }
 div.main .content .posts {
-  {{ $nbPosts := len (where .Data.Pages "Params.best" true)  }}
+  {{ $pages := .Data.Pages }}
+  {{ if .IsHome }}
+  {{ $pages = .Site.RegularPages }}
+  {{ end }}
+  {{ $nbPosts := len (where $pages "Params.best" true)  }}
   {{ if gt $nbPosts 0 }}
   margin-bottom: 4em;
   {{ end }}


### PR DESCRIPTION
Upgrading Hugo to 0.58.1 caused issues for me related to #138  and https://github.com/gohugoio/hugoThemes/issues/682. 

This PR fixes my issues, and to the best of my knowledge (testing it with v0.57.2), it is backwards compatible.  

Behavior without any changes:

<img width="525" alt="Screenshot 2019-09-12 21 32 55" src="https://user-images.githubusercontent.com/3526705/64837848-4a09ff00-d5a5-11e9-8f01-b5c63f4c2ee7.png">

Behavior with my changes:

<img width="718" alt="Screenshot 2019-09-12 21 32 31" src="https://user-images.githubusercontent.com/3526705/64837923-ac62ff80-d5a5-11e9-8d2e-8da59f57b452.png">

Behavior with Best posts:

<img width="714" alt="Screenshot 2019-09-12 21 57 07" src="https://user-images.githubusercontent.com/3526705/64838489-47f56f80-d5a8-11e9-9c42-7ef65503dd0d.png">



Edited to remove issues I was having with Best posts.



