### PR TITLE
Adding the option to turn off Google Analytics & Fix Latest Posts List

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,11 +10,13 @@
 
             {{ if isset .Site.Params "latestpostcount" }}
                 <div class="posts">
-                {{ $nbPosts := len (where .Data.Pages "Section" "blog") }}
+                {{ $blogPosts := (where .Site.RegularPages "Section" "blog") }}
+                {{ $nbPosts := len $blogPosts }}
                 {{ if gt $nbPosts 0 }}
                     <div class="page-heading">Latest posts</div>
                     <ul>
-                    {{ range (first .Site.Params.latestpostcount (where .Pages "Section" "blog")).GroupByDate "Jan, 2006" "desc" }}
+                    
+                    {{ range (first .Site.Params.latestpostcount $blogPosts).GroupByDate "Jan, 2006" "desc" }}
                         <li class="groupby">{{ .Key }}</li>
                         {{ range sort .Pages "Date" "desc" }}
                             {{ partial "li.html" . }}

--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -41,7 +41,9 @@ fathom('trackPageview');
 <!-- / Fathom -->
 {{ end }}
 
+{{ if .Site.Params.googleAnalyticsEnabled }}
 {{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
 
 <script>
   window.onload = function() {


### PR DESCRIPTION
I started this PR so that I could turn off google analytics, just like I can turn off disqus. That involves adding a boolean in the configuration and an if statement in the `footer.html` partial to check for it and leave out the `_internal/google_analytics_async.html` partial if it's set to true.

I also ran into https://github.com/mtn/cocoa-eh-hugo-theme/issues/143 on Hugo v0.61.0, and fixed it here. That fix is a bit buried because I did some refactoring in on the index.html template. The core of the fix is that the code checks `.Site.RegularPages` instead of `.Data.Pages`. I did that [here](https://github.com/mtn/cocoa-eh-hugo-theme/pull/144/files#diff-1578c58a761c0846adb0e788c860a12bR13)

Edit: I just saw https://github.com/mtn/cocoa-eh-hugo-theme/pull/141, which also seems to fix #143. I'm happy to remove my fix in this PR if you'd like to merge that one first.

Fixes #143