### PR TITLE
Fix syntax highlighting issues with Chroma

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ hugo -t cocoa-eh
 
 If you want a simple blog you can just use the `exampleSite`. The [wiki](https://github.com/mtn/cocoa-eh-hugo-theme/wiki) includes helpful details should you need more.
 
+## Contributing
+
+See the [contributing guidelines](CONTRIBUTING.md).
+
 ## License
 
 Licensed under the MIT License. See the [LICENSE](https://github.com/mtn/cocoa-eh-hugo-theme/blob/master/LICENSE) file for more details.

--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -523,6 +523,9 @@ div.main .content .markdown h6 {
   margin-bottom: 1rem;
   letter-spacing: none;
 }
+pre {
+  overflow-x: auto;
+}
 div.main .content .markdown code,
 div.main .content .markdown pre {
   font-family: 'Menlo', monospace;

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -20,6 +20,8 @@
   <style type="text/css" media="screen">
     {{ partial "css/highlight.min.css" . | safeCSS }}
   </style>
+{{ else }}
+  <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.css">
 {{ end }}
 
 {{ if .Site.Params.progressively }}


### PR DESCRIPTION
Minor changes along the lines of https://themes.gohugo.io/beautifulhugo/ for supporting both `highlight.js` (theme-default) and `chroma` (hugo-native) highlighting solutions:

* To use `highlightling.js`, use these settings within `config.toml`:

```toml
pygmentsCodeFences = false
pygmentsUseClasses = false

[params]
highlightjs = true
```

* To rely on Chroma instead:

```toml
pygmentsCodeFences = true
pygmentsUseClasses = true

[params]
highlightjs = false
```

Using the new server side syntax highilighting provided by Chroma requires generating an additional CSS file. For example, for styling according to the `trac` theme, one would run:

```
hugo gen chromastyles --style=trac > static/css/syntax.css
```

> - The `main.css` file has been changed to properly display the horizontal scrollbar in code fences when using Chroma for syntax highlighting.
> - The README has been updated to point to the contributing guidelines.

